### PR TITLE
Remove unused Strings in the library

### DIFF
--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<resources>
-    <string name="app_name">Library</string>
-    <string name="default_progressbar">Default Progressbar:</string>
-</resources>


### PR DESCRIPTION
Unused Strings that may interfer with Strings having the same name in a third-party project
